### PR TITLE
fix: improve loading state display for quick stats when no data is availabe

### DIFF
--- a/web/marmot/src/routes/+page.svelte
+++ b/web/marmot/src/routes/+page.svelte
@@ -656,7 +656,13 @@
 					<div class="flex items-center justify-between mb-2">
 						<Icon icon={stat.icon} class="w-8 h-8 text-gray-400 dark:text-gray-500" />
 					</div>
-					<div class="w-20 h-9 bg-gray-200 dark:bg-gray-700 animate-pulse rounded mb-1"></div>
+					{#if !isLoading}
+						<div class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-1">
+							{stat.value.toLocaleString()}
+						</div>
+					{:else}
+						<div class="w-20 h-9 bg-gray-200 dark:bg-gray-700 animate-pulse rounded mb-1"></div>
+					{/if}
 					<p class="text-sm font-medium text-gray-600 dark:text-gray-400">{stat.label}</p>
 				</div>
 			{/each}


### PR DESCRIPTION
Hey, when I logged in first time it shows loading status for quick stats even though there is no stats available yet. I fixed the missing `if` condition when `showGettingStarted` is `True`.

before:
<img width="1388" height="776" alt="image" src="https://github.com/user-attachments/assets/fe57bd06-2fba-4b0c-acb5-364a66c6302e" />

after:
<img width="1388" height="776" alt="image" src="https://github.com/user-attachments/assets/b7a19116-2e38-4e75-bdb9-da24b922d14a" />
