### PR TITLE
fix: update job run query to retrieve username of the creator

### DIFF
--- a/internal/core/runs/schedule_store.go
+++ b/internal/core/runs/schedule_store.go
@@ -509,9 +509,10 @@ func (r *SchedulePostgresRepository) GetJobRun(ctx context.Context, id string) (
 			COALESCE(s.name, 'Manual Run') as pipeline_name,
 			COALESCE(s.plugin_id, '') as source_name,
 			COALESCE(s.config, '{}'::jsonb) as config,
-			COALESCE(s.created_by, '') as created_by
+			COALESCE(u.username, '') as created_by
 		FROM ingestion_job_runs jr
 		LEFT JOIN ingestion_schedules s ON jr.schedule_id = s.id
+		LEFT JOIN users u ON s.created_by = u.id::text
 		WHERE jr.id = $1`
 
 	run := &JobRun{}
@@ -642,9 +643,10 @@ func (r *SchedulePostgresRepository) ListJobRuns(ctx context.Context, scheduleID
 			COALESCE(s.name, 'Manual Run') as pipeline_name,
 			COALESCE(s.plugin_id, '') as source_name,
 			COALESCE(s.config, '{}'::jsonb) as config,
-			COALESCE(s.created_by, '') as created_by
+			COALESCE(u.username, '') as created_by
 		FROM ingestion_job_runs jr
 		LEFT JOIN ingestion_schedules s ON jr.schedule_id = s.id
+		LEFT JOIN users u ON s.created_by = u.id::text
 		%s
 		ORDER BY jr.created_at DESC
 		LIMIT $%d OFFSET $%d`, whereClause, argPos, argPos+1)


### PR DESCRIPTION
Hey,

I simply added an extra join to get the `username` field from the `users` table and now we return that `username` instead of the `ingestion_schedules.created_by` value. Resolves #54

<img width="1352" height="761" alt="image" src="https://github.com/user-attachments/assets/4df98aed-e737-4017-aa65-654ace41e4d7" />

<img width="773" height="315" alt="image" src="https://github.com/user-attachments/assets/79c84c8c-ec90-4daf-8000-96d42a0519fe" />

