### PR TITLE
feat: add table previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ internal/staticfiles/build/
 testenv
 
 web/marmot/src/lib/icon-bundle.ts
+
+logs/

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -93,6 +93,65 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/assets/preview/{id}": {
+            "get": {
+                "description": "Fetches sample data from the asset's data source. Requires assets:preview permission.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "assets"
+                ],
+                "summary": "Get preview data for an asset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_assets.PreviewResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing assets:preview permission",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Data preview not supported for this asset",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/ingestion/runs": {
             "get": {
                 "produces": [
@@ -7141,6 +7200,27 @@ const docTemplate = `{
                 },
                 "period": {
                     "type": "string"
+                }
+            }
+        },
+        "v1_assets.PreviewResponse": {
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {}
+                    }
+                },
+                "total_rows": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -86,6 +86,65 @@
                 }
             }
         },
+        "/api/v1/assets/preview/{id}": {
+            "get": {
+                "description": "Fetches sample data from the asset's data source. Requires assets:preview permission.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "assets"
+                ],
+                "summary": "Get preview data for an asset",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Asset ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_assets.PreviewResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Missing assets:preview permission",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    },
+                    "501": {
+                        "description": "Data preview not supported for this asset",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/ingestion/runs": {
             "get": {
                 "produces": [
@@ -7134,6 +7193,27 @@
                 },
                 "period": {
                     "type": "string"
+                }
+            }
+        },
+        "v1_assets.PreviewResponse": {
+            "type": "object",
+            "properties": {
+                "column_names": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {}
+                    }
+                },
+                "total_rows": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1199,6 +1199,20 @@ definitions:
       period:
         type: string
     type: object
+  v1_assets.PreviewResponse:
+    properties:
+      column_names:
+        items:
+          type: string
+        type: array
+      rows:
+        items:
+          items: {}
+          type: array
+        type: array
+      total_rows:
+        type: integer
+    type: object
   v1_assets.RemoveTermRequest:
     properties:
       term_id:
@@ -1926,6 +1940,46 @@ paths:
       summary: Start search reindex
       tags:
       - admin
+  /api/v1/assets/preview/{id}:
+    get:
+      description: Fetches sample data from the asset's data source. Requires assets:preview
+        permission.
+      parameters:
+      - description: Asset ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1_assets.PreviewResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse'
+        "403":
+          description: Missing assets:preview permission
+          schema:
+            $ref: '#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse'
+        "501":
+          description: Data preview not supported for this asset
+          schema:
+            $ref: '#/definitions/github_com_marmotdata_marmot_internal_api_v1_common.ErrorResponse'
+      summary: Get preview data for an asset
+      tags:
+      - assets
   /api/v1/ingestion/runs:
     get:
       parameters:

--- a/internal/api/v1/assets/handler.go
+++ b/internal/api/v1/assets/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/marmotdata/marmot/internal/core/runs"
 	"github.com/marmotdata/marmot/internal/core/team"
 	"github.com/marmotdata/marmot/internal/core/user"
+	"github.com/marmotdata/marmot/internal/crypto"
 	"github.com/marmotdata/marmot/internal/metrics"
 )
 
@@ -22,8 +23,10 @@ type Handler struct {
 	authService      auth.Service
 	metricsService   *metrics.Service
 	runService       runs.Service
+	scheduleService  *runs.ScheduleService
 	teamService      *team.Service
 	assetRuleService assetrule.Service
+	encryptor        *crypto.Encryptor
 	config           *config.Config
 }
 
@@ -34,8 +37,10 @@ func NewHandler(
 	authService auth.Service,
 	metricsService *metrics.Service,
 	runService runs.Service,
+	scheduleService *runs.ScheduleService,
 	teamService *team.Service,
 	assetRuleService assetrule.Service,
+	encryptor *crypto.Encryptor,
 	config *config.Config,
 ) *Handler {
 	return &Handler{
@@ -45,8 +50,10 @@ func NewHandler(
 		authService:      authService,
 		metricsService:   metricsService,
 		runService:       runService,
+		scheduleService:  scheduleService,
 		teamService:      teamService,
 		assetRuleService: assetRuleService,
+		encryptor:        encryptor,
 		config:           config,
 	}
 }
@@ -87,6 +94,16 @@ func (h *Handler) Routes() []common.Route {
 			Middleware: []func(http.HandlerFunc) http.HandlerFunc{
 				common.WithAuth(h.userService, h.authService, h.config),
 				common.RequirePermission(h.userService, "assets", "manage"),
+			},
+		},
+		{
+			Path:    "/api/v1/assets/preview/{id}",
+			Method:  http.MethodGet,
+			Handler: h.getAssetPreview,
+			Middleware: []func(http.HandlerFunc) http.HandlerFunc{
+				common.WithAuth(h.userService, h.authService, h.config),
+				common.RequirePermission(h.userService, "assets", "preview"),
+				common.WithRateLimit(h.config, 30, 60), // 30 requests per 60 seconds
 			},
 		},
 		{

--- a/internal/api/v1/assets/preview.go
+++ b/internal/api/v1/assets/preview.go
@@ -51,7 +51,7 @@ func (h *Handler) getAssetPreview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !isTableAsset(assetObj.Type) {
+	if !isQueryableAsset(assetObj.Type) {
 		common.RespondError(w, http.StatusNotImplemented, "preview not supported for this asset type")
 		return
 	}
@@ -135,17 +135,12 @@ func (h *Handler) getAssetPreview(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// isTableAsset checks if an asset type represents a table-like entity
-func isTableAsset(assetType string) bool {
-	if assetType == "" {
+// isQueryableAsset checks if an asset type represents a table-like entity
+func isQueryableAsset(assetType string) bool {
+	switch strings.ToLower(assetType) {
+	case "table", "view":
+		return true
+	default:
 		return false
 	}
-	tableKeywords := []string{"table", "view"}
-	lowerType := strings.ToLower(assetType)
-	for _, keyword := range tableKeywords {
-		if strings.Contains(lowerType, keyword) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/api/v1/assets/preview.go
+++ b/internal/api/v1/assets/preview.go
@@ -119,7 +119,7 @@ func (h *Handler) getAssetPreview(w http.ResponseWriter, r *http.Request) {
 			Str("provider", providerName).
 			Msg("Failed to fetch sample data")
 
-		common.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to fetch data: %v", err))
+		common.RespondError(w, http.StatusInternalServerError, "failed to fetch data")
 		return
 	}
 

--- a/internal/api/v1/assets/preview.go
+++ b/internal/api/v1/assets/preview.go
@@ -1,0 +1,151 @@
+package assets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/marmotdata/marmot/internal/api/v1/common"
+	"github.com/marmotdata/marmot/internal/core/runs"
+	"github.com/marmotdata/marmot/internal/plugin"
+	"github.com/rs/zerolog/log"
+)
+
+// PreviewResponse represents the response structure for preview data
+type PreviewResponse struct {
+	ColumnNames []string        `json:"column_names"`
+	Rows        [][]interface{} `json:"rows"`
+	TotalRows   *int            `json:"total_rows,omitempty"`
+}
+
+// getAssetPreview handles GET /api/v1/assets/preview/{id}
+// @Summary Get preview data for an asset
+// @Description Fetches sample data from the asset's data source. Requires assets:preview permission.
+// @Tags assets
+// @Produce json
+// @Param id path string true "Asset ID"
+// @Success 200 {object} PreviewResponse
+// @Failure 400 {object} common.ErrorResponse
+// @Failure 403 {object} common.ErrorResponse "Missing assets:preview permission"
+// @Failure 404 {object} common.ErrorResponse
+// @Failure 501 {object} common.ErrorResponse "Data preview not supported for this asset"
+// @Failure 500 {object} common.ErrorResponse
+// @Router /api/v1/assets/preview/{id} [get]
+func (h *Handler) getAssetPreview(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	assetID := r.PathValue("id")
+
+	if assetID == "" {
+		common.RespondError(w, http.StatusBadRequest, "asset ID is required")
+		return
+	}
+
+	assetObj, err := h.assetService.Get(ctx, assetID)
+	if err != nil {
+		log.Error().Err(err).Str("asset_id", assetID).Msg("Failed to fetch asset")
+		common.RespondError(w, http.StatusNotFound, "asset not found")
+		return
+	}
+
+	if !isTableAsset(assetObj.Type) {
+		common.RespondError(w, http.StatusNotImplemented, "preview not supported for this asset type")
+		return
+	}
+
+	if len(assetObj.Providers) == 0 {
+		common.RespondError(w, http.StatusBadRequest, "asset has no provider information")
+		return
+	}
+
+	providerName := assetObj.Providers[0]
+
+	// we lower provider name to match plugin id but this is an assumption.
+	// we should consider storing plugin id separately.
+	pluginSource, err := plugin.GetRegistry().GetSource(strings.ToLower(providerName))
+	if err != nil {
+		log.Error().Err(err).Str("provider", providerName).Msg("Plugin not found")
+		common.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("plugin not found for asset provider: %s", providerName))
+		return
+	}
+
+	dataFetcher, ok := pluginSource.(plugin.DataFetcher)
+	if !ok {
+		log.Debug().Str("provider", providerName).Msg("Plugin does not support data preview")
+		common.RespondError(w, http.StatusNotImplemented, fmt.Sprintf("data preview not supported for %s assets", providerName))
+		return
+	}
+
+	// Get schedule from asset association
+	schedule, err := h.scheduleService.GetScheduleForAsset(ctx, assetObj.ID)
+	if err != nil {
+		if errors.Is(err, runs.ErrScheduleNotFound) {
+			common.RespondError(w, http.StatusBadRequest, "no schedule associated with this asset; run an ingestion job first")
+			return
+		}
+		log.Error().Err(err).Str("asset_id", assetID).Msg("Failed to get schedule for asset")
+		common.RespondError(w, http.StatusInternalServerError, "failed to look up schedule for asset")
+		return
+	}
+
+	var pluginConfig plugin.RawPluginConfig
+
+	if h.encryptor != nil {
+		if err := runs.DecryptScheduleConfig(schedule, h.encryptor); err != nil {
+			log.Error().Err(err).Msg("Failed to decrypt schedule config")
+			common.RespondError(w, http.StatusInternalServerError, "failed to decrypt schedule configuration")
+			return
+		}
+	}
+
+	pluginConfig = schedule.Config
+
+	// Set a timeout for data fetching
+	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	log.Info().
+		Str("asset_id", assetID).
+		Str("provider", providerName).
+		Msg("Fetching preview data")
+
+	columnNames, rows, err := dataFetcher.FetchSampleData(fetchCtx, pluginConfig, assetObj)
+	if err != nil {
+		log.Error().Err(err).
+			Str("asset_id", assetID).
+			Str("provider", providerName).
+			Msg("Failed to fetch sample data")
+
+		common.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to fetch data: %v", err))
+		return
+	}
+
+	response := PreviewResponse{
+		ColumnNames: columnNames,
+		Rows:        rows,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Error().Err(err).Msg("Failed to encode response")
+	}
+}
+
+// isTableAsset checks if an asset type represents a table-like entity
+func isTableAsset(assetType string) bool {
+	if assetType == "" {
+		return false
+	}
+	tableKeywords := []string{"table", "view"}
+	lowerType := strings.ToLower(assetType)
+	for _, keyword := range tableKeywords {
+		if strings.Contains(lowerType, keyword) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/v1/server.go
+++ b/internal/api/v1/server.go
@@ -504,7 +504,7 @@ func New(config *config.Config, db *pgxpool.Pool) *Server {
 
 	server.handlers = []interface{ Routes() []common.Route }{
 		health.NewHandler(),
-		assets.NewHandler(assetSvc, assetDocsSvc, userSvc, authSvc, metricsService, runsSvc, teamSvc, assetRuleSvc, config),
+		assets.NewHandler(assetSvc, assetDocsSvc, userSvc, authSvc, metricsService, runsSvc, scheduleSvc, teamSvc, assetRuleSvc, scheduleEncryptor, config),
 		users.NewHandler(userSvc, authSvc, config),
 		auth.NewHandler(authSvc, oauthManager, userSvc, config),
 		lineage.NewHandler(lineageSvc, userSvc, authSvc, config),

--- a/internal/core/runs/schedule_service.go
+++ b/internal/core/runs/schedule_service.go
@@ -58,6 +58,14 @@ func (s *ScheduleService) GetScheduleByName(ctx context.Context, name string) (*
 	return s.repo.GetScheduleByName(ctx, name)
 }
 
+func (s *ScheduleService) LinkAssetsByMRN(ctx context.Context, scheduleID string, assetMRNs []string) error {
+	return s.repo.LinkAssetsByMRN(ctx, scheduleID, assetMRNs)
+}
+
+func (s *ScheduleService) GetScheduleForAsset(ctx context.Context, assetID string) (*Schedule, error) {
+	return s.repo.GetScheduleForAsset(ctx, assetID)
+}
+
 func (s *ScheduleService) UpdateSchedule(ctx context.Context, id string, name, pluginID string, config map[string]interface{}, cronExpression string, enabled bool) (*Schedule, error) {
 	existing, err := s.repo.GetSchedule(ctx, id)
 	if err != nil {

--- a/internal/core/runs/schedule_store.go
+++ b/internal/core/runs/schedule_store.go
@@ -112,6 +112,10 @@ type ScheduleRepository interface {
 	CompleteJobRun(ctx context.Context, id string, status string, errorMessage *string, assetsCreated, assetsUpdated, assetsDeleted, lineageCreated, documentationAdded int) error
 	ReleaseExpiredClaims(ctx context.Context, expiry time.Duration) (int, error)
 	CancelJobRun(ctx context.Context, id string) error
+
+	// Asset-schedule associations
+	LinkAssetsByMRN(ctx context.Context, scheduleID string, assetMRNs []string) error
+	GetScheduleForAsset(ctx context.Context, assetID string) (*Schedule, error)
 }
 
 type SchedulePostgresRepository struct {
@@ -1030,4 +1034,68 @@ func (r *SchedulePostgresRepository) maskJobRunConfig(run *JobRun) {
 
 	// Mask sensitive fields using the ConfigSpec
 	run.Config = plugin.MaskSensitiveFieldsFromSpec(plugin.RawPluginConfig(run.Config), entry.Meta.ConfigSpec)
+}
+
+// LinkAssetsByMRN links assets (identified by MRN) to a schedule.
+// Resolves MRNs to asset IDs and upserts into asset_schedules table.
+func (r *SchedulePostgresRepository) LinkAssetsByMRN(ctx context.Context, scheduleID string, assetMRNs []string) error {
+	if len(assetMRNs) == 0 {
+		return nil
+	}
+
+	query := `
+		INSERT INTO asset_schedules (asset_id, schedule_id)
+		SELECT a.id, $1::uuid
+		FROM assets a
+		WHERE a.mrn = ANY($2)
+		ON CONFLICT (asset_id, schedule_id) DO UPDATE SET updated_at = NOW()`
+
+	_, err := r.db.Exec(ctx, query, scheduleID, assetMRNs)
+	if err != nil {
+		return fmt.Errorf("linking assets to schedule: %w", err)
+	}
+
+	return nil
+}
+
+// GetScheduleForAsset returns the most recently linked schedule for an asset.
+// Returns ErrScheduleNotFound if no schedule is associated with the asset.
+func (r *SchedulePostgresRepository) GetScheduleForAsset(ctx context.Context, assetID string) (*Schedule, error) {
+	query := `
+		SELECT s.id, s.name, s.plugin_id, s.config, s.cron_expression, s.enabled,
+		       s.last_run_at, s.next_run_at, s.created_by, s.created_at, s.updated_at
+		FROM ingestion_schedules s
+		JOIN asset_schedules asset_sched ON s.id = asset_sched.schedule_id
+		WHERE asset_sched.asset_id = $1
+		ORDER BY asset_sched.updated_at DESC
+		LIMIT 1`
+
+	schedule := &Schedule{}
+	var configJSON []byte
+	err := r.db.QueryRow(ctx, query, assetID).Scan(
+		&schedule.ID,
+		&schedule.Name,
+		&schedule.PluginID,
+		&configJSON,
+		&schedule.CronExpression,
+		&schedule.Enabled,
+		&schedule.LastRunAt,
+		&schedule.NextRunAt,
+		&schedule.CreatedBy,
+		&schedule.CreatedAt,
+		&schedule.UpdatedAt,
+	)
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrScheduleNotFound
+		}
+		return nil, fmt.Errorf("getting schedule for asset: %w", err)
+	}
+
+	if err := json.Unmarshal(configJSON, &schedule.Config); err != nil {
+		return nil, fmt.Errorf("unmarshaling config: %w", err)
+	}
+
+	return schedule, nil
 }

--- a/internal/core/runs/scheduler.go
+++ b/internal/core/runs/scheduler.go
@@ -440,12 +440,16 @@ func (w *worker) executeJob(ctx context.Context, run *JobRun) error {
 
 	assetsCreated := 0
 	assetsUpdated := 0
+	assetMRNs := make([]string, 0, len(response.Assets))
 	for _, ar := range response.Assets {
 		switch ar.Status {
 		case StatusCreated:
 			assetsCreated++
 		case StatusUpdated:
 			assetsUpdated++
+		}
+		if ar.MRN != "" {
+			assetMRNs = append(assetMRNs, ar.MRN)
 		}
 	}
 
@@ -497,6 +501,17 @@ func (w *worker) executeJob(ctx context.Context, run *JobRun) error {
 		TotalEntities:      len(result.Assets) + len(result.Lineage) + len(result.Documentation),
 	}
 	_ = w.runsService.CompleteRun(ctx, pluginRun.RunID, plugin.StatusCompleted, summary, "")
+
+	// Link assets to this schedule for preview lookups (non-fatal if it fails)
+	if len(assetMRNs) > 0 {
+		if err := w.service.LinkAssetsByMRN(ctx, *run.ScheduleID, assetMRNs); err != nil {
+			log.Warn().
+				Err(err).
+				Str("run_id", run.ID).
+				Str("schedule_id", *run.ScheduleID).
+				Msg("Failed to link assets to schedule")
+		}
+	}
 
 	err = w.service.CompleteJobRun(
 		ctx,

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -142,6 +142,13 @@ type StatefulSource interface {
 	SupportsStatefulIngestion() bool
 }
 
+// DataFetcher is an optional interface that plugins can implement to support
+// data preview functionality. Plugins that can query/fetch sample data from
+// their data sources should implement this interface.
+type DataFetcher interface {
+	FetchSampleData(ctx context.Context, config RawPluginConfig, a *asset.Asset) (columnNames []string, rows [][]interface{}, err error)
+}
+
 // GetConfigType attempts to extract the config type from a source by unmarshaling into an empty interface and using reflection
 func GetConfigType(raw RawPluginConfig, source Source) interface{} {
 	validated, err := source.Validate(raw)

--- a/internal/plugin/providers/bigquery/source.go
+++ b/internal/plugin/providers/bigquery/source.go
@@ -576,6 +576,127 @@ func (s *Source) extractRequiredFields(fields bigquery.Schema) []string {
 	return required
 }
 
+// FetchSampleData implements the DataFetcher interface to retrieve sample data from a BigQuery table
+func (s *Source) FetchSampleData(ctx context.Context, config plugin.RawPluginConfig, a *asset.Asset) ([]string, [][]interface{}, error) {
+	if a == nil || a.Metadata == nil {
+		return nil, nil, fmt.Errorf("asset or asset metadata is nil")
+	}
+
+	parsedConfig, err := plugin.UnmarshalPluginConfig[Config](config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing plugin config: %w", err)
+	}
+	s.config = parsedConfig
+
+	dataset, _ := a.Metadata["dataset_id"].(string)
+	table, _ := a.Metadata["table_id"].(string)
+
+	if dataset == "" {
+		return nil, nil, fmt.Errorf("could not determine dataset from asset metadata")
+	}
+	if table == "" && a.Name != nil {
+		table = *a.Name
+	}
+	if table == "" {
+		return nil, nil, fmt.Errorf("could not determine table name from asset metadata")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := s.initClient(fetchCtx); err != nil {
+		return nil, nil, fmt.Errorf("connecting to BigQuery: %w", err)
+	}
+	defer s.closeClient()
+
+	tableID := fmt.Sprintf("%s.%s.%s", s.config.ProjectID, dataset, table)
+
+	query := fmt.Sprintf("SELECT * FROM `%s` LIMIT 20",
+		strings.ReplaceAll(tableID, "`", "``"))
+
+	q := s.client.Query(query)
+	q.Location = "US"
+
+	log.Debug().
+		Str("dataset", dataset).
+		Str("table", table).
+		Msg("Fetching sample data")
+
+	it, err := q.Read(fetchCtx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("querying table: %w", err)
+	}
+
+	var columnNames []string
+	var dataRows [][]interface{}
+
+	for {
+		row := make([]bigquery.Value, 0)
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to scan row, skipping")
+			continue
+		}
+
+		if len(columnNames) == 0 {
+			schema := it.Schema
+			for _, field := range schema {
+				columnNames = append(columnNames, field.Name)
+			}
+		}
+
+		// Convert values to JSON-friendly formats
+		convertedRow := make([]interface{}, len(row))
+		for i, val := range row {
+			convertedRow[i] = convertBigQueryValue(val)
+		}
+
+		dataRows = append(dataRows, convertedRow)
+	}
+
+	log.Debug().
+		Int("columns", len(columnNames)).
+		Int("rows", len(dataRows)).
+		Msg("Successfully fetched sample data")
+
+	return columnNames, dataRows, nil
+}
+
+// convertBigQueryValue converts BigQuery-specific types to JSON-friendly formats
+func convertBigQueryValue(val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
+
+	switch v := val.(type) {
+	case []byte:
+		// For binary types, convert to hex string
+		return fmt.Sprintf("0x%x", v)
+	case time.Time:
+		// Return time as ISO string
+		return v.Format(time.RFC3339)
+	case map[string]bigquery.Value:
+		// Convert struct/record types
+		converted := make(map[string]interface{})
+		for k, val := range v {
+			converted[k] = convertBigQueryValue(val)
+		}
+		return converted
+	case []bigquery.Value:
+		// Convert array types
+		converted := make([]interface{}, len(v))
+		for i, val := range v {
+			converted[i] = convertBigQueryValue(val)
+		}
+		return converted
+	default:
+		return val
+	}
+}
+
 func init() {
 	meta := plugin.PluginMeta{
 		ID:          "bigquery",

--- a/internal/plugin/providers/bigquery/source.go
+++ b/internal/plugin/providers/bigquery/source.go
@@ -131,33 +131,38 @@ func (s *Source) Discover(ctx context.Context, pluginConfig plugin.RawPluginConf
 	var assets []asset.Asset
 	var lineages []lineage.LineageEdge
 
-	if s.config.IncludeDatasets {
-		log.Debug().Msg("Starting dataset discovery")
-		datasetAssets, err := s.discoverDatasets(ctx)
-		if err != nil {
-			log.Warn().Err(err).Msg("Failed to discover datasets")
-		} else {
+	// Discover datasets
+	log.Debug().Msg("Starting dataset discovery")
+	datasetAssets, err := s.discoverDatasets(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to discover datasets")
+	} else {
+		if s.config.IncludeDatasets {
 			assets = append(assets, datasetAssets...)
 			log.Debug().Int("count", len(datasetAssets)).Msg("Discovered datasets")
 		}
+	}
 
-		for _, datasetAsset := range datasetAssets {
-			if datasetAsset.Type != "Dataset" {
-				continue
-			}
+	// Discover tables in all datasets
+	for _, datasetAsset := range datasetAssets {
+		if datasetAsset.Type != "Dataset" {
+			continue
+		}
 
-			datasetID := *datasetAsset.Name
+		datasetID := *datasetAsset.Name
 
-			log.Debug().Str("dataset", datasetID).Msg("Starting table discovery")
-			tableAssets, err := s.discoverTables(ctx, datasetID)
-			if err != nil {
-				log.Warn().Err(err).Str("dataset", datasetID).Msg("Failed to discover tables")
-				continue
-			}
+		log.Debug().Str("dataset", datasetID).Msg("Starting table discovery")
+		tableAssets, err := s.discoverTables(ctx, datasetID)
+		if err != nil {
+			log.Warn().Err(err).Str("dataset", datasetID).Msg("Failed to discover tables")
+			continue
+		}
 
-			assets = append(assets, tableAssets...)
-			log.Debug().Int("count", len(tableAssets)).Str("dataset", datasetID).Msg("Discovered tables")
+		assets = append(assets, tableAssets...)
+		log.Debug().Int("count", len(tableAssets)).Str("dataset", datasetID).Msg("Discovered tables")
 
+		// Only create lineage if datasets are included
+		if s.config.IncludeDatasets {
 			for _, tableAsset := range tableAssets {
 				lineages = append(lineages, lineage.LineageEdge{
 					Source: *datasetAsset.MRN,

--- a/internal/plugin/providers/bigquery/source.go
+++ b/internal/plugin/providers/bigquery/source.go
@@ -63,15 +63,26 @@ const (
 	TableTypeExternal TableType = "EXTERNAL"
 )
 
-func (c *Config) ApplyDefaults() {
+func (c *Config) ApplyDefaults(rawConfig plugin.RawPluginConfig) {
 	if c.MaxConcurrentRequests == 0 {
 		c.MaxConcurrentRequests = 10
 	}
-	c.IncludeDatasets = true
-	c.IncludeTableStats = true
-	c.IncludeViews = true
-	c.IncludeExternalTables = true
-	c.ExcludeSystemDatasets = true
+
+	if _, exists := rawConfig["include_datasets"]; !exists {
+		c.IncludeDatasets = true
+	}
+	if _, exists := rawConfig["include_table_stats"]; !exists {
+		c.IncludeTableStats = true
+	}
+	if _, exists := rawConfig["include_views"]; !exists {
+		c.IncludeViews = true
+	}
+	if _, exists := rawConfig["include_external_tables"]; !exists {
+		c.IncludeExternalTables = true
+	}
+	if _, exists := rawConfig["exclude_system_datasets"]; !exists {
+		c.ExcludeSystemDatasets = true
+	}
 }
 
 func (s *Source) Validate(rawConfig plugin.RawPluginConfig) (plugin.RawPluginConfig, error) {
@@ -80,7 +91,7 @@ func (s *Source) Validate(rawConfig plugin.RawPluginConfig) (plugin.RawPluginCon
 		return nil, fmt.Errorf("unmarshaling config: %w", err)
 	}
 
-	config.ApplyDefaults()
+	config.ApplyDefaults(rawConfig)
 
 	if err := plugin.ValidateStruct(config); err != nil {
 		return nil, err

--- a/internal/plugin/providers/bigquery/source.go
+++ b/internal/plugin/providers/bigquery/source.go
@@ -630,12 +630,18 @@ func (s *Source) FetchSampleData(ctx context.Context, config plugin.RawPluginCon
 	query := fmt.Sprintf("SELECT * FROM `%s` LIMIT 20",
 		strings.ReplaceAll(tableID, "`", "``"))
 
+	datasetMeta, err := s.client.Dataset(dataset).Metadata(fetchCtx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting dataset metadata: %w", err)
+	}
+
 	q := s.client.Query(query)
-	q.Location = "US"
+	q.Location = datasetMeta.Location
 
 	log.Debug().
 		Str("dataset", dataset).
 		Str("table", table).
+		Str("location", q.Location).
 		Msg("Fetching sample data")
 
 	it, err := q.Read(fetchCtx)

--- a/internal/plugin/providers/bigquery/source.go
+++ b/internal/plugin/providers/bigquery/source.go
@@ -136,11 +136,9 @@ func (s *Source) Discover(ctx context.Context, pluginConfig plugin.RawPluginConf
 	datasetAssets, err := s.discoverDatasets(ctx)
 	if err != nil {
 		log.Warn().Err(err).Msg("Failed to discover datasets")
-	} else {
-		if s.config.IncludeDatasets {
-			assets = append(assets, datasetAssets...)
-			log.Debug().Int("count", len(datasetAssets)).Msg("Discovered datasets")
-		}
+	} else if s.config.IncludeDatasets {
+		assets = append(assets, datasetAssets...)
+		log.Debug().Int("count", len(datasetAssets)).Msg("Discovered datasets")
 	}
 
 	// Discover tables in all datasets

--- a/internal/plugin/providers/clickhouse/source.go
+++ b/internal/plugin/providers/clickhouse/source.go
@@ -12,6 +12,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -491,6 +493,119 @@ func (s *Source) collectTableStatistics(ctx context.Context, dbName string, asse
 	}
 
 	return statistics
+}
+
+
+// FetchSampleData implements the DataFetcher interface to retrieve sample data from a ClickHouse table.
+func (s *Source) FetchSampleData(ctx context.Context, config plugin.RawPluginConfig, a *asset.Asset) ([]string, [][]interface{}, error) {
+	if a == nil || a.Metadata == nil {
+		return nil, nil, fmt.Errorf("asset or asset metadata is nil")
+	}
+
+	parsedConfig, err := plugin.UnmarshalPluginConfig[Config](config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing plugin config: %w", err)
+	}
+	s.config = parsedConfig
+
+	database, _ := a.Metadata["database"].(string)
+	table, _ := a.Metadata["table_name"].(string)
+
+	if database == "" {
+		return nil, nil, fmt.Errorf("could not determine database from asset metadata")
+	}
+	if table == "" && a.Name != nil {
+		table = *a.Name
+	}
+	if table == "" {
+		return nil, nil, fmt.Errorf("could not determine table name from asset metadata")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := s.initConnection(fetchCtx); err != nil {
+		return nil, nil, fmt.Errorf("connecting to ClickHouse: %w", err)
+	}
+	defer s.closeConnection()
+
+	//nolint:gosec // G201: inputs sanitized via quoteIdentifier
+	query := fmt.Sprintf("SELECT * FROM %s.%s LIMIT 20", 
+		quoteIdentifier(database),
+		quoteIdentifier(table),
+	)
+
+	log.Debug().
+		Str("database", database).
+		Str("table", table).
+		Msg("Fetching sample data from ClickHouse")
+
+	rows, err := s.conn.Query(fetchCtx, query)
+	if err != nil {
+		return nil, nil, fmt.Errorf("querying table: %w", err)
+	}
+	defer rows.Close()
+
+	colTypes := rows.ColumnTypes()
+
+	columnNames := make([]string, len(colTypes))
+	for i, ct := range colTypes {
+		columnNames[i] = ct.Name()
+	}
+
+	var dataRows [][]interface{}
+	for rows.Next() {
+		scanPtrs := make([]reflect.Value, len(colTypes))
+		scanDests := make([]interface{}, len(colTypes))
+		for i, ct := range colTypes {
+			ptr := reflect.New(ct.ScanType())
+			scanPtrs[i] = ptr
+			scanDests[i] = ptr.Interface()
+		}
+
+		if err := rows.Scan(scanDests...); err != nil {
+			log.Warn().Err(err).Msg("Failed to scan row, skipping")
+			continue
+		}
+
+		converted := make([]interface{}, len(colTypes))
+		for i, ptr := range scanPtrs {
+			converted[i] = convertClickHouseValue(ptr.Elem().Interface())
+		}
+		dataRows = append(dataRows, converted)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating rows: %w", err)
+	}
+
+	log.Debug().
+		Int("columns", len(columnNames)).
+		Int("rows", len(dataRows)).
+		Msg("Successfully fetched sample data from ClickHouse")
+
+	return columnNames, dataRows, nil
+}
+
+// convertClickHouseValue converts ClickHouse-specific types to JSON-friendly formats.
+func convertClickHouseValue(val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
+	switch v := val.(type) {
+	case []byte:
+		return fmt.Sprintf("0x%x", v)
+	case time.Time:
+		return v.Format(time.RFC3339)
+	default:
+		return val
+	}
+}
+
+// quoteIdentifier wraps an identifier in backticks for ClickHouse SQL.
+func quoteIdentifier(id string) string {
+	id = strings.ReplaceAll(id, "\x00", "")
+	return "`" + strings.ReplaceAll(id, "`", "``") + "`"
 }
 
 func init() {

--- a/internal/plugin/providers/mysql/source.go
+++ b/internal/plugin/providers/mysql/source.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/marmotdata/marmot/internal/core/asset"
@@ -394,6 +395,115 @@ func (s *Source) discoverForeignKeys(ctx context.Context, dbName string) ([]line
 	}
 
 	return lineages, nil
+}
+
+// FetchSampleData implements the DataFetcher interface to retrieve sample data from a MySQL table
+func (s *Source) FetchSampleData(ctx context.Context, config plugin.RawPluginConfig, a *asset.Asset) ([]string, [][]interface{}, error) {
+	if a == nil || a.Metadata == nil {
+		return nil, nil, fmt.Errorf("asset or asset metadata is nil")
+	}
+
+	parsedConfig, err := plugin.UnmarshalPluginConfig[Config](config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing plugin config: %w", err)
+	}
+	s.config = parsedConfig
+
+	database, _ := a.Metadata["database"].(string)
+	table, _ := a.Metadata["table_name"].(string)
+
+	if database == "" {
+		return nil, nil, fmt.Errorf("could not determine database from asset metadata")
+	}
+	if table == "" && a.Name != nil {
+		table = *a.Name
+	}
+	if table == "" {
+		return nil, nil, fmt.Errorf("could not determine table name from asset metadata")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := s.initConnection(fetchCtx, database); err != nil {
+		return nil, nil, fmt.Errorf("connecting to database %s: %w", database, err)
+	}
+	defer s.closeConnection()
+
+	//nolint:gosec // G201: inputs sanitized via quoteIdentifier
+	query := fmt.Sprintf("SELECT * FROM `%s` LIMIT 20", strings.ReplaceAll(table, "`", "``"))
+
+	log.Debug().
+		Str("database", database).
+		Str("table", table).
+		Msg("Fetching sample data")
+
+	rows, err := s.db.QueryContext(fetchCtx, query)
+	if err != nil {
+		return nil, nil, fmt.Errorf("querying table: %w", err)
+	}
+	defer rows.Close()
+
+	columnNames, err := rows.Columns()
+	if err != nil {
+		return nil, nil, fmt.Errorf("getting column names: %w", err)
+	}
+
+	var dataRows [][]interface{}
+	for rows.Next() {
+		// Create a slice of interface{} to scan into
+		values := make([]interface{}, len(columnNames))
+		valuePtrs := make([]interface{}, len(columnNames))
+		for i := range columnNames {
+			valuePtrs[i] = &values[i]
+		}
+
+		if err := rows.Scan(valuePtrs...); err != nil {
+			log.Warn().Err(err).Msg("Failed to scan row, skipping")
+			continue
+		}
+
+		// Convert MySQL-specific types to JSON-friendly formats
+		convertedValues := make([]interface{}, len(values))
+		for i, val := range values {
+			convertedValues[i] = convertMySQLValue(val)
+		}
+
+		dataRows = append(dataRows, convertedValues)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating rows: %w", err)
+	}
+
+	log.Debug().
+		Int("columns", len(columnNames)).
+		Int("rows", len(dataRows)).
+		Msg("Successfully fetched sample data")
+
+	return columnNames, dataRows, nil
+}
+
+// convertMySQLValue converts MySQL-specific types to JSON-friendly formats
+func convertMySQLValue(val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
+
+	switch v := val.(type) {
+	case []byte:
+		if utf8.Valid(v) {
+			return string(v)
+		}
+		// For actual binary data, convert to hex string
+		return fmt.Sprintf("0x%x", v)
+	case time.Time:
+		// Return time as ISO string
+		return v.Format(time.RFC3339)
+	default:
+		// For other types, return as is
+		return val
+	}
 }
 
 func init() {

--- a/internal/plugin/providers/mysql/source.go
+++ b/internal/plugin/providers/mysql/source.go
@@ -431,7 +431,10 @@ func (s *Source) FetchSampleData(ctx context.Context, config plugin.RawPluginCon
 	defer s.closeConnection()
 
 	//nolint:gosec // G201: inputs sanitized via quoteIdentifier
-	query := fmt.Sprintf("SELECT * FROM `%s` LIMIT 20", strings.ReplaceAll(table, "`", "``"))
+	query := fmt.Sprintf("SELECT * FROM %s.%s LIMIT 20",
+		quoteIdentifier(database),
+		quoteIdentifier(table),
+	)
 
 	log.Debug().
 		Str("database", database).
@@ -482,6 +485,12 @@ func (s *Source) FetchSampleData(ctx context.Context, config plugin.RawPluginCon
 		Msg("Successfully fetched sample data")
 
 	return columnNames, dataRows, nil
+}
+
+// quoteIdentifier wraps an identifier in backticks for MySQL SQL.
+func quoteIdentifier(id string) string {
+	id = strings.ReplaceAll(id, "\x00", "")
+	return "`" + strings.ReplaceAll(id, "`", "``") + "`"
 }
 
 // convertMySQLValue converts MySQL-specific types to JSON-friendly formats

--- a/internal/plugin/providers/postgresql/source.go
+++ b/internal/plugin/providers/postgresql/source.go
@@ -758,6 +758,134 @@ func (s *Source) collectTableStatistics(ctx context.Context, dbName string, asse
 	return statistics
 }
 
+// FetchSampleData implements the DataFetcher interface to retrieve sample data from a PostgreSQL table
+func (s *Source) FetchSampleData(ctx context.Context, config plugin.RawPluginConfig, a *asset.Asset) ([]string, [][]interface{}, error) {
+	if a == nil || a.Metadata == nil {
+		return nil, nil, fmt.Errorf("asset or asset metadata is nil")
+	}
+
+	parsedConfig, err := plugin.UnmarshalPluginConfig[Config](config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing plugin config: %w", err)
+	}
+	s.config = parsedConfig
+
+	database, _ := a.Metadata["database"].(string)
+	schema, _ := a.Metadata["schema"].(string)
+	table, _ := a.Metadata["table_name"].(string)
+
+	if database == "" {
+		return nil, nil, fmt.Errorf("could not determine database from asset metadata")
+	}
+	if table == "" && a.Name != nil {
+		table = *a.Name
+	}
+	if schema == "" {
+		return nil, nil, fmt.Errorf("could not determine schema from asset metadata")
+	}
+	if table == "" {
+		return nil, nil, fmt.Errorf("could not determine table name from asset metadata")
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if err := s.initConnection(fetchCtx, database); err != nil {
+		return nil, nil, fmt.Errorf("connecting to database %s: %w", database, err)
+	}
+	defer s.closeConnection()
+
+	query := fmt.Sprintf(
+		"SELECT * FROM %s.%s LIMIT 20",
+		pgx.Identifier{schema}.Sanitize(),
+		pgx.Identifier{table}.Sanitize(),
+	)
+
+	log.Debug().
+		Str("database", database).
+		Str("schema", schema).
+		Str("table", table).
+		Msg("Fetching sample data")
+
+	rows, err := s.pool.Query(fetchCtx, query)
+	if err != nil {
+		return nil, nil, fmt.Errorf("querying table: %w", err)
+	}
+	defer rows.Close()
+
+	fieldDescriptions := rows.FieldDescriptions()
+	columnNames := make([]string, len(fieldDescriptions))
+	for i, fd := range fieldDescriptions {
+		columnNames[i] = string(fd.Name)
+	}
+
+	var dataRows [][]interface{}
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to scan row, skipping")
+			continue
+		}
+		
+		// Convert pgx-specific types to JSON-friendly formats
+		convertedValues := make([]interface{}, len(values))
+		for i, val := range values {
+			convertedValues[i] = convertPgxValue(val)
+		}
+		
+		dataRows = append(dataRows, convertedValues)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterating rows: %w", err)
+	}
+
+	log.Debug().
+		Int("columns", len(columnNames)).
+		Int("rows", len(dataRows)).
+		Msg("Successfully fetched sample data")
+
+	return columnNames, dataRows, nil
+}
+
+// convertPgxValue converts PostgreSQL-specific types to JSON-friendly formats
+func convertPgxValue(val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
+
+	switch v := val.(type) {
+	case []byte:
+		// Convert byte arrays to hex string (for UUIDs, bytea, etc.)
+		// Try to parse as UUID first
+		if len(v) == 16 {
+			// Format as UUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+			return fmt.Sprintf("%x-%x-%x-%x-%x", v[0:4], v[4:6], v[6:8], v[8:10], v[10:16])
+		}
+		// For other byte arrays, return as hex string
+		return fmt.Sprintf("\\x%x", v)
+	case [16]byte:
+		// UUID as fixed array
+		return fmt.Sprintf("%x-%x-%x-%x-%x", v[0:4], v[4:6], v[6:8], v[8:10], v[10:16])
+	case time.Time:
+		// Return time as ISO string
+		return v.Format(time.RFC3339)
+	case map[string]interface{}:
+		// JSON/JSONB already comes as map, keep as is
+		return v
+	case []interface{}:
+		// Arrays - convert each element
+		converted := make([]interface{}, len(v))
+		for i, item := range v {
+			converted[i] = convertPgxValue(item)
+		}
+		return converted
+	default:
+		// For other types, return as is
+		return val
+	}
+}
+
 func init() {
 	meta := plugin.PluginMeta{
 		ID:          "postgresql",

--- a/internal/store/postgres/migrations/000040_add_assets_preview_permission.sql
+++ b/internal/store/postgres/migrations/000040_add_assets_preview_permission.sql
@@ -1,0 +1,16 @@
+-- Add preview permission for assets
+INSERT INTO permissions (name, description, resource_type, action) VALUES
+('preview_assets', 'Preview sample data from table assets', 'assets', 'preview');
+
+-- Grant preview permission to admin role only (least privilege by default)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT
+    (SELECT id FROM roles WHERE name = 'admin'),
+    id
+FROM permissions
+WHERE name = 'preview_assets';
+
+---- create above / drop below ----
+
+DELETE FROM role_permissions WHERE permission_id = (SELECT id FROM permissions WHERE name = 'preview_assets');
+DELETE FROM permissions WHERE name = 'preview_assets';

--- a/internal/store/postgres/migrations/000041_create_asset_schedules.sql
+++ b/internal/store/postgres/migrations/000041_create_asset_schedules.sql
@@ -1,0 +1,14 @@
+CREATE TABLE asset_schedules (
+    asset_id    VARCHAR(255) NOT NULL REFERENCES assets(id) ON DELETE CASCADE,
+    schedule_id UUID         NOT NULL REFERENCES ingestion_schedules(id) ON DELETE CASCADE,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (asset_id, schedule_id)
+);
+
+CREATE INDEX idx_asset_schedules_asset_id    ON asset_schedules(asset_id);
+CREATE INDEX idx_asset_schedules_schedule_id ON asset_schedules(schedule_id);
+
+---- create above / drop below ----
+
+DROP TABLE IF EXISTS asset_schedules;

--- a/web/marmot/src/components/asset/DataPreviewTable.svelte
+++ b/web/marmot/src/components/asset/DataPreviewTable.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+	interface Props {
+		columnNames: string[];
+		rows: any[][];
+		loading?: boolean;
+		error?: string | null;
+	}
+
+	let { columnNames = [], rows = [], loading = false, error = null }: Props = $props();
+
+	// Column width state
+	let columnWidths = $state<number[]>([]);
+	let resizingColumn = $state<number | null>(null);
+	let startX = $state(0);
+	let startWidth = $state(0);
+
+	// Initialize column widths when columnNames change
+	$effect(() => {
+		if (columnNames.length > 0 && columnWidths.length !== columnNames.length) {
+			columnWidths = columnNames.map(() => 200); // Default width
+		}
+	});
+
+	function handleResizeStart(index: number, e: MouseEvent) {
+		resizingColumn = index;
+		startX = e.clientX;
+		startWidth = columnWidths[index];
+		e.preventDefault();
+	}
+
+	function handleResize(e: MouseEvent) {
+		if (resizingColumn !== null) {
+			const diff = e.clientX - startX;
+			const newWidth = Math.max(100, startWidth + diff); // Min width 100px
+			columnWidths[resizingColumn] = newWidth;
+		}
+	}
+
+	function handleResizeEnd() {
+		resizingColumn = null;
+	}
+
+	$effect(() => {
+		if (resizingColumn !== null) {
+			document.addEventListener('mousemove', handleResize);
+			document.addEventListener('mouseup', handleResizeEnd);
+			return () => {
+				document.removeEventListener('mousemove', handleResize);
+				document.removeEventListener('mouseup', handleResizeEnd);
+			};
+		}
+	});
+</script>
+
+<div class="w-full">
+	{#if loading}
+		<div class="flex items-center justify-center py-12">
+			<div class="animate-spin rounded-full h-8 w-8 border-b-2 border-earthy-terracotta-700"></div>
+		</div>
+	{:else if error}
+		<div class="flex items-center justify-center py-12">
+			<div
+				class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/50 rounded-lg p-4 text-red-600 dark:text-red-400 max-w-2xl"
+			>
+				<div class="font-semibold mb-1">Preview Not Available</div>
+				<div class="text-sm">{error}</div>
+			</div>
+		</div>
+	{:else if columnNames.length === 0 || rows.length === 0}
+		<div class="flex items-center justify-center py-12">
+			<div class="text-gray-500 dark:text-gray-400">No data available for preview</div>
+		</div>
+	{:else}
+		<div
+			class="overflow-x-auto max-h-[600px] -mx-8 px-8 {resizingColumn !== null
+				? 'select-none'
+				: ''}"
+		>
+			<table class="w-full divide-y divide-gray-200 dark:divide-gray-700">
+				<thead class="bg-gray-100 dark:bg-gray-700 sticky top-0 z-10">
+					<tr>
+						{#each columnNames as columnName, index}
+							<th
+								class="px-4 py-2 text-left text-xs font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wider whitespace-nowrap relative border-r border-gray-200 dark:border-gray-700"
+								style="width: {columnWidths[index]}px; min-width: {columnWidths[
+									index
+								]}px; max-width: {columnWidths[index]}px;"
+							>
+								<div class="flex items-center justify-between">
+									<span class="truncate">{columnName}</span>
+								</div>
+								<div
+									class="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-earthy-terracotta-500 group"
+									onmousedown={(e) => handleResizeStart(index, e)}
+								>
+									<div class="w-1 h-full bg-transparent group-hover:bg-earthy-terracotta-500"></div>
+								</div>
+							</th>
+						{/each}
+					</tr>
+				</thead>
+				<tbody class="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+					{#each rows as row, rowIndex}
+						<tr
+							class="{rowIndex % 2 === 0
+								? 'bg-white dark:bg-gray-900'
+								: 'bg-gray-50 dark:bg-gray-800'} hover:bg-gray-50 dark:hover:bg-gray-700"
+						>
+							{#each row as cell, cellIndex}
+								<td
+									class="px-4 py-2 text-sm text-gray-900 dark:text-gray-100 whitespace-nowrap overflow-hidden text-ellipsis border-r border-gray-200 dark:border-gray-700"
+									style="width: {columnWidths[cellIndex]}px; min-width: {columnWidths[
+										cellIndex
+									]}px; max-width: {columnWidths[cellIndex]}px;"
+									title={cell != null ? String(cell) : ''}
+								>
+									{#if cell == null}
+										<span class="text-gray-400 italic">null</span>
+									{:else if typeof cell === 'number'}
+										<span class="font-mono">{String(cell)}</span>
+									{:else if typeof cell === 'object'}
+										{JSON.stringify(cell)}
+									{:else}
+										{String(cell)}
+									{/if}
+								</td>
+							{/each}
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<div class="mt-4 text-sm text-gray-500 dark:text-gray-400 text-center">
+			Showing {rows.length} row{rows.length !== 1 ? 's' : ''}
+		</div>
+	{/if}
+</div>
+
+<style>
+	:global(.overflow-x-auto::-webkit-scrollbar) {
+		height: 10px;
+	}
+
+	:global(.overflow-x-auto::-webkit-scrollbar-track) {
+		background: transparent;
+	}
+
+	:global(.overflow-x-auto::-webkit-scrollbar-thumb) {
+		background: #d1d5db;
+		border-radius: 3px;
+	}
+
+	:global(.overflow-x-auto::-webkit-scrollbar-thumb:hover) {
+		background: #9ca3af;
+	}
+
+	:global(.overflow-x-auto) {
+		scrollbar-width: thin;
+		scrollbar-color: #d1d5db transparent;
+	}
+</style>

--- a/web/marmot/src/lib/api.ts
+++ b/web/marmot/src/lib/api.ts
@@ -34,3 +34,20 @@ export async function fetchApi(endpoint: string, options: FetchApiOptions = {}) 
 
 	return response;
 }
+
+export interface AssetPreviewResponse {
+	column_names: string[];
+	rows: any[][];
+	total_rows?: number;
+}
+
+export async function fetchAssetPreview(assetId: string): Promise<AssetPreviewResponse> {
+	const response = await fetchApi(`/assets/preview/${assetId}`);
+	if (!response.ok) {
+		const errorData = await response.json();
+		const error: any = new Error(errorData.error || 'Failed to fetch preview');
+		error.status = response.status;
+		throw error;
+	}
+	return await response.json();
+}

--- a/web/marmot/src/routes/discover/[type]/[service]/[name]/+page.svelte
+++ b/web/marmot/src/routes/discover/[type]/[service]/[name]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
-	import { fetchApi } from '$lib/api';
+	import { fetchApi, fetchAssetPreview, type AssetPreviewResponse } from '$lib/api';
 	import type { Asset, EnrichedExternalLink } from '$lib/assets/types';
 	import AssetBlade from '$components/asset/AssetBlade.svelte';
 	import DocumentationSystem from '$components/docs/DocumentationSystem.svelte';
@@ -12,6 +12,7 @@
 	import AssetEnvironmentsView from '$components/asset/AssetEnvironmentsView.svelte';
 	import RunHistory from '$components/runs/RunHistory.svelte';
 	import CodeBlock from '$components/editor/CodeBlock.svelte';
+	import DataPreviewTable from '$components/asset/DataPreviewTable.svelte';
 	import Tabs, { type Tab } from '$components/ui/Tabs.svelte';
 	import Icon from '$components/ui/Icon.svelte';
 	import IconifyIcon from '@iconify/svelte';
@@ -42,6 +43,10 @@
 	let userDescription = $state('');
 	let isEditingDescription = $state(false);
 	let savingDescription = $state(false);
+
+	let previewData: AssetPreviewResponse | null = $state(null);
+	let previewLoading = $state(false);
+	let previewError: string | null = $state(null);
 
 	let canManageAssets = $derived(auth.hasPermission('assets', 'manage'));
 
@@ -79,6 +84,12 @@
 
 	function handleBack() {
 		window.history.back();
+	}
+
+	function isTableAsset(asset: Asset | null): boolean {
+		if (!asset?.type) return false;
+		const tableKeywords = ['table', 'view', 'dataset'];
+		return tableKeywords.some((keyword) => asset.type.toLowerCase().includes(keyword));
 	}
 
 	function getIconName(asset: Asset): string {
@@ -182,6 +193,7 @@
 		{ id: 'documentation', label: 'Documentation', icon: 'material-symbols:description' },
 		{ id: 'metadata', label: 'Metadata', icon: 'material-symbols:data-object' },
 		{ id: 'query', label: 'Query', icon: 'material-symbols:code' },
+		{ id: 'preview', label: 'Preview', icon: 'material-symbols:preview' },
 		{ id: 'environments', label: 'Environments', icon: 'material-symbols:deployed-code' },
 		{ id: 'schema', label: 'Schema', icon: 'material-symbols:table' },
 		{ id: 'run-history', label: 'Run History', icon: 'material-symbols:history' },
@@ -196,6 +208,7 @@
 			)
 				return false;
 			if (tab.id === 'query' && !asset?.query) return false;
+			if (tab.id === 'preview' && !isTableAsset(asset)) return false;
 			if (tab.id === 'run-history' && !asset?.has_run_history) return false;
 			return true;
 		})
@@ -211,8 +224,37 @@
 		if (asset?.id) {
 			fetchOwners();
 			userDescription = asset.user_description || '';
+
+			// Fetch preview data if asset is a table
+			if (isTableAsset(asset)) {
+				fetchPreviewData();
+			}
 		}
 	});
+
+	async function fetchPreviewData() {
+		if (!asset?.id) return;
+
+		previewLoading = true;
+		previewError = null;
+		previewData = null;
+
+		try {
+			previewData = await fetchAssetPreview(asset.id);
+		} catch (err: any) {
+			let errorMsg = 'Failed to fetch preview data';
+			if (err.status === 403) {
+				errorMsg =
+					'You do not have permission to preview data. The "assets:preview" permission is required.';
+			} else if (err instanceof Error) {
+				errorMsg = err.message;
+			}
+			previewError = errorMsg;
+			console.error('Preview fetch error:', err);
+		} finally {
+			previewLoading = false;
+		}
+	}
 </script>
 
 <div class="h-full flex">
@@ -403,9 +445,13 @@
 				{/if}
 			</div>
 
-			<div class="flex-1 overflow-y-auto overflow-x-auto px-8">
-				<div class="pb-16 {activeTab === 'lineage' ? '' : 'max-w-7xl mx-auto'}">
-					<div class="rounded-lg max-w-full overflow-x-auto">
+			<div class="flex-1 overflow-y-auto {activeTab === 'preview' ? '' : 'overflow-x-auto'} px-8">
+				<div
+					class="pb-16 {activeTab === 'lineage' || activeTab === 'preview'
+						? ''
+						: 'max-w-7xl mx-auto'}"
+				>
+					<div class="rounded-lg max-w-full {activeTab === 'preview' ? '' : 'overflow-x-auto'}">
 						{#if !asset}
 							<div class="bg-gray-50 dark:bg-gray-800 rounded-lg p-4">
 								<p class="text-gray-500 dark:text-gray-400">Loading asset information...</p>
@@ -435,6 +481,13 @@
 									</div>
 								{/if}
 							</div>
+						{:else if activeTab === 'preview'}
+							<DataPreviewTable
+								columnNames={previewData?.column_names ?? []}
+								rows={previewData?.rows ?? []}
+								loading={previewLoading}
+								error={previewError}
+							/>
 						{:else if activeTab === 'environments'}
 							<div class="mt-6">
 								{#if asset.environments && Object.keys(asset.environments).length > 0}


### PR DESCRIPTION
Hey @charlie-haley, I’ve added a table preview feature for assets. It’s available for all providers that support discovering table/view like assets, except Trino, as we’re having some issues with the discovered asset metadata. Only permitted users can access table previews. WDYT?


<img width="1857" height="836" alt="image" src="https://github.com/user-attachments/assets/ece306a7-1d82-44bd-ad0b-80de3bdcd11d" />

<img width="1344" height="604" alt="image" src="https://github.com/user-attachments/assets/9da59b09-f257-4cdb-acd7-40d77fe84571" />

