### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/web/docs/docs/cli.md
+++ b/web/docs/docs/cli.md
@@ -26,6 +26,14 @@ import { Steps, Step, Tabs, TabPanel, TipBox } from '@site/src/components/Steps'
 ]}>
 <TabPanel>
 
+**Homebrew**
+
+```bash
+brew install marmot
+```
+
+**Install script**
+
 ```bash
 curl -fsSL get.marmotdata.io | sh
 ```


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/281688 added support for Marmot into Homebrew Core. Because of Homebrew's popularity we favor this installation path over our installation script.
