### PR TITLE
Dockerfile: copy sdk instead of client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM golang:1.26 AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./
-COPY client/ client/
+COPY sdk/ sdk/
 RUN go mod download
 
 COPY . .


### PR DESCRIPTION
The `client` dir was recently removed, in favor of `sdk`.