### PR TITLE
Fix/issue 179 metadata rendering for object arrays and multiline strings

### DIFF
--- a/web/marmot/src/components/shared/MetadataView.svelte
+++ b/web/marmot/src/components/shared/MetadataView.svelte
@@ -200,11 +200,37 @@
 		return String(value);
 	}
 
+	function formatJson(value: unknown): string {
+		return JSON.stringify(value, null, 2);
+	}
+
 	function formatDisplayValue(value: unknown): string {
 		if (isObject(value)) {
-			return JSON.stringify(value, null, 2);
+			return formatJson(value);
 		}
 		return value?.toString() || '';
+	}
+
+	function truncatePreview(value: string, maxLength = 160): string {
+		return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+	}
+
+	function getObjectPreview(value: unknown): string {
+		const lines = formatJson(value).split('\n');
+		return truncatePreview(lines.slice(0, 4).join('\n') + (lines.length > 4 ? '\n...' : ''));
+	}
+
+	function getArrayPreview(value: unknown[]): string {
+		const preview = value
+			.slice(0, 2)
+			.map((item) => formatDisplayValue(item).replace(/\s+/g, ' '))
+			.join(' | ');
+		return truncatePreview(preview + (value.length > 2 ? ' | ...' : ''));
+	}
+
+	function getStringPreview(value: string): string {
+		const lines = value.split('\n');
+		return truncatePreview(lines.slice(0, 2).join('\n') + (lines.length > 2 ? '\n...' : ''));
 	}
 
 	function isExpandableString(value: unknown): value is string {
@@ -235,6 +261,41 @@
 	const metadataEntries = $derived(Object.entries(metadata));
 </script>
 
+{#snippet metadataDisclosure(
+	key: string,
+	label: string,
+	preview: string,
+	content: string,
+	compact = false
+)}
+	<details
+		class="group/details"
+		open={expandedDetails[key]}
+		ontoggle={(e) => (expandedDetails[key] = e.currentTarget.open)}
+	>
+		<summary
+			class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-start {compact
+				? 'text-sm'
+				: ''}"
+		>
+			<Arrow expanded={expandedDetails[key]} />
+			<span class="ml-1 min-w-0">
+				<span class="block">{label}</span>
+				<span
+					class="metadata-preview block max-w-full {preview.includes('\n')
+						? 'line-clamp-2 whitespace-pre-line'
+						: 'truncate'} break-all font-mono text-xs text-gray-500 dark:text-gray-400"
+				>
+					{preview}
+				</span>
+			</span>
+		</summary>
+		<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded {compact ? 'text-xs' : ''}">
+			<pre class="font-mono whitespace-pre-wrap break-all">{content}</pre>
+		</div>
+	</details>
+{/snippet}
+
 {#if isReadOnly}
 	<!-- Read-Only Mode -->
 	<div class="space-y-2">
@@ -253,39 +314,19 @@
 						</dt>
 						<dd class="text-sm text-gray-900 dark:text-gray-100 flex-1 min-w-0">
 							{#if isObject(value)}
-								<details class="group">
-									<summary
-										class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center"
-									>
-										<Arrow expanded={false} />
-										<span class="ml-1">View Details</span>
-									</summary>
-									<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded">
-										<pre
-											class="text-xs text-gray-800 dark:text-gray-200 overflow-x-auto">{JSON.stringify(
-												value,
-												null,
-												2
-											)}</pre>
-									</div>
-								</details>
+								{@render metadataDisclosure(
+									key,
+									'View Details',
+									getObjectPreview(value),
+									formatJson(value)
+								)}
 							{:else if isArray(value) && containsObject(value)}
-								<details class="group">
-									<summary
-										class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center"
-									>
-										<Arrow expanded={false} />
-										<span class="ml-1">View array</span>
-									</summary>
-									<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded">
-										<pre
-											class="text-xs text-gray-800 dark:text-gray-200 overflow-x-auto">{JSON.stringify(
-												value,
-												null,
-												2
-											)}</pre>
-									</div>
-								</details>
+								{@render metadataDisclosure(
+									key,
+									'View array',
+									getArrayPreview(value),
+									formatJson(value)
+								)}
 							{:else if isArray(value)}
 								<div class="flex flex-wrap gap-1">
 									{#each value as item, i (i)}
@@ -304,19 +345,12 @@
 									{/if}
 								</div>
 							{:else if isExpandableString(value)}
-								<details class="group">
-									<summary
-										class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center"
-									>
-										<Arrow expanded={false} />
-										<span class="ml-1">View text</span>
-									</summary>
-									<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded">
-										<pre class="font-mono whitespace-pre-wrap break-all">{formatDisplayValue(
-												value
-											)}</pre>
-									</div>
-								</details>
+								{@render metadataDisclosure(
+									key,
+									'View text',
+									getStringPreview(value),
+									formatDisplayValue(value)
+								)}
 							{:else}
 								<span class="font-mono break-all">{truncateValue(formatDisplayValue(value))}</span>
 							{/if}
@@ -414,47 +448,21 @@
 												</div>
 											</div>
 										{:else if isObject(value)}
-											<details
-												class="group/details"
-												open={expandedDetails[key]}
-												ontoggle={(e) => (expandedDetails[key] = e.currentTarget.open)}
-											>
-												<summary
-													class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center text-sm"
-												>
-													<Arrow expanded={expandedDetails[key]} />
-													<span class="ml-1">View object</span>
-												</summary>
-												<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded text-xs">
-													<pre
-														class="text-gray-800 dark:text-gray-200 overflow-x-auto">{JSON.stringify(
-															value,
-															null,
-															2
-														)}</pre>
-												</div>
-											</details>
+											{@render metadataDisclosure(
+												key,
+												'View object',
+												getObjectPreview(value),
+												formatJson(value),
+												true
+											)}
 										{:else if isArray(value) && containsObject(value)}
-											<details
-												class="group/details"
-												open={expandedDetails[key]}
-												ontoggle={(e) => (expandedDetails[key] = e.currentTarget.open)}
-											>
-												<summary
-													class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center text-sm"
-												>
-													<Arrow expanded={expandedDetails[key]} />
-													<span class="ml-1">View array</span>
-												</summary>
-												<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded text-xs">
-													<pre
-														class="text-gray-800 dark:text-gray-200 overflow-x-auto">{JSON.stringify(
-															value,
-															null,
-															2
-														)}</pre>
-												</div>
-											</details>
+											{@render metadataDisclosure(
+												key,
+												'View array',
+												getArrayPreview(value),
+												formatJson(value),
+												true
+											)}
 										{:else if isArray(value)}
 											<div class="flex flex-wrap gap-1.5">
 												{#each value as item, i (i)}
@@ -466,23 +474,13 @@
 												{/each}
 											</div>
 										{:else if isExpandableString(value)}
-											<details
-												class="group/details"
-												open={expandedDetails[key]}
-												ontoggle={(e) => (expandedDetails[key] = e.currentTarget.open)}
-											>
-												<summary
-													class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center text-sm"
-												>
-													<Arrow expanded={expandedDetails[key]} />
-													<span class="ml-1">View text</span>
-												</summary>
-												<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded text-xs">
-													<pre class="font-mono whitespace-pre-wrap break-all">{formatDisplayValue(
-															value
-														)}</pre>
-												</div>
-											</details>
+											{@render metadataDisclosure(
+												key,
+												'View text',
+												getStringPreview(value),
+												formatDisplayValue(value),
+												true
+											)}
 										{:else}
 											<span class="px-2 py-1 text-sm rounded-full {getValueClass(value)}">
 												{formatDisplayValue(value)}
@@ -581,3 +579,9 @@
 	onConfirm={confirmDeleteMetadata}
 	onCancel={cancelDeleteMetadata}
 />
+
+<style>
+	details[open] .metadata-preview {
+		display: none;
+	}
+</style>

--- a/web/marmot/src/components/shared/MetadataView.svelte
+++ b/web/marmot/src/components/shared/MetadataView.svelte
@@ -203,8 +203,8 @@
 		return value?.toString() || '';
 	}
 
-	function isMultilineString(value: unknown): value is string {
-		return typeof value === 'string' && value.includes('\n');
+	function isExpandableString(value: unknown): value is string {
+		return typeof value === 'string' && (value.includes('\n') || value.length > 200);
 	}
 
 	function truncateValue(value: string): string {
@@ -282,8 +282,20 @@
 										</span>
 									{/if}
 								</div>
-							{:else if isMultilineString(value)}
-								<pre class="font-mono whitespace-pre-wrap break-all">{truncateValue(value)}</pre>
+							{:else if isExpandableString(value)}
+								<details class="group">
+									<summary
+										class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center"
+									>
+										<Arrow expanded={false} />
+										<span class="ml-1">View text</span>
+									</summary>
+									<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded">
+										<pre class="font-mono whitespace-pre-wrap break-all">{formatDisplayValue(
+												value
+											)}</pre>
+									</div>
+								</details>
 							{:else}
 								<span class="font-mono break-all">{truncateValue(formatDisplayValue(value))}</span>
 							{/if}
@@ -411,8 +423,24 @@
 													</span>
 												{/each}
 											</div>
-										{:else if isMultilineString(value)}
-											<pre class="font-mono whitespace-pre-wrap break-all">{value}</pre>
+										{:else if isExpandableString(value)}
+											<details
+												class="group/details"
+												open={expandedDetails[key]}
+												ontoggle={(e) => (expandedDetails[key] = e.currentTarget.open)}
+											>
+												<summary
+													class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center text-sm"
+												>
+													<Arrow expanded={expandedDetails[key]} />
+													<span class="ml-1">View text</span>
+												</summary>
+												<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded text-xs">
+													<pre class="font-mono whitespace-pre-wrap break-all">{formatDisplayValue(
+															value
+														)}</pre>
+												</div>
+											</details>
 										{:else}
 											<span class="px-2 py-1 text-sm rounded-full {getValueClass(value)}">
 												{formatDisplayValue(value)}

--- a/web/marmot/src/components/shared/MetadataView.svelte
+++ b/web/marmot/src/components/shared/MetadataView.svelte
@@ -89,6 +89,10 @@
 		return Array.isArray(value);
 	}
 
+	function containsObject(value: unknown[]): boolean {
+		return value.some((item) => isObject(item));
+	}
+
 	function getValueClass(value: unknown): string {
 		if (typeof value === 'boolean') {
 			return value
@@ -265,6 +269,23 @@
 											)}</pre>
 									</div>
 								</details>
+							{:else if isArray(value) && containsObject(value)}
+								<details class="group">
+									<summary
+										class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center"
+									>
+										<Arrow expanded={false} />
+										<span class="ml-1">View array</span>
+									</summary>
+									<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded">
+										<pre
+											class="text-xs text-gray-800 dark:text-gray-200 overflow-x-auto">{JSON.stringify(
+												value,
+												null,
+												2
+											)}</pre>
+									</div>
+								</details>
 							{:else if isArray(value)}
 								<div class="flex flex-wrap gap-1">
 									{#each value as item, i (i)}
@@ -403,6 +424,27 @@
 												>
 													<Arrow expanded={expandedDetails[key]} />
 													<span class="ml-1">View object</span>
+												</summary>
+												<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded text-xs">
+													<pre
+														class="text-gray-800 dark:text-gray-200 overflow-x-auto">{JSON.stringify(
+															value,
+															null,
+															2
+														)}</pre>
+												</div>
+											</details>
+										{:else if isArray(value) && containsObject(value)}
+											<details
+												class="group/details"
+												open={expandedDetails[key]}
+												ontoggle={(e) => (expandedDetails[key] = e.currentTarget.open)}
+											>
+												<summary
+													class="cursor-pointer text-earthy-terracotta-700 dark:text-earthy-terracotta-500 hover:text-earthy-terracotta-800 dark:hover:text-earthy-terracotta-600 flex items-center text-sm"
+												>
+													<Arrow expanded={expandedDetails[key]} />
+													<span class="ml-1">View array</span>
 												</summary>
 												<div class="mt-2 p-2 bg-gray-50 dark:bg-gray-900 rounded text-xs">
 													<pre

--- a/web/marmot/src/components/shared/MetadataView.svelte
+++ b/web/marmot/src/components/shared/MetadataView.svelte
@@ -85,7 +85,7 @@
 		return typeof value === 'object' && value !== null && !Array.isArray(value);
 	}
 
-	function isArray(value: unknown): boolean {
+	function isArray(value: unknown): value is unknown[] {
 		return Array.isArray(value);
 	}
 
@@ -196,6 +196,17 @@
 		return String(value);
 	}
 
+	function formatDisplayValue(value: unknown): string {
+		if (isObject(value)) {
+			return JSON.stringify(value, null, 2);
+		}
+		return value?.toString() || '';
+	}
+
+	function isMultilineString(value: unknown): value is string {
+		return typeof value === 'string' && value.includes('\n');
+	}
+
 	function truncateValue(value: string): string {
 		if (!maxCharLength || value.length <= maxCharLength) return value;
 		return value.slice(0, maxCharLength) + '...';
@@ -259,9 +270,9 @@
 									{#each value as item, i (i)}
 										{#if i < 5}
 											<span
-												class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded"
+												class="px-2 py-0.5 text-xs bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded whitespace-pre-wrap break-all"
 											>
-												{truncateValue(item?.toString() || '')}
+												{truncateValue(formatDisplayValue(item))}
 											</span>
 										{/if}
 									{/each}
@@ -271,10 +282,10 @@
 										</span>
 									{/if}
 								</div>
+							{:else if isMultilineString(value)}
+								<pre class="font-mono whitespace-pre-wrap break-all">{truncateValue(value)}</pre>
 							{:else}
-								<span class="font-mono break-all">
-									{truncateValue(value?.toString() || '')}
-								</span>
+								<span class="font-mono break-all">{truncateValue(formatDisplayValue(value))}</span>
 							{/if}
 						</dd>
 					</div>
@@ -394,15 +405,17 @@
 											<div class="flex flex-wrap gap-1.5">
 												{#each value as item, i (i)}
 													<span
-														class="px-2 py-0.5 text-xs bg-earthy-terracotta-100 dark:bg-earthy-terracotta-900 text-earthy-terracotta-700 dark:text-earthy-terracotta-100 rounded"
+														class="px-2 py-0.5 text-xs bg-earthy-terracotta-100 dark:bg-earthy-terracotta-900 text-earthy-terracotta-700 dark:text-earthy-terracotta-100 rounded whitespace-pre-wrap break-all"
 													>
-														{item?.toString() || ''}
+														{formatDisplayValue(item)}
 													</span>
 												{/each}
 											</div>
+										{:else if isMultilineString(value)}
+											<pre class="font-mono whitespace-pre-wrap break-all">{value}</pre>
 										{:else}
 											<span class="px-2 py-1 text-sm rounded-full {getValueClass(value)}">
-												{value?.toString() || ''}
+												{formatDisplayValue(value)}
 											</span>
 										{/if}
 									</td>


### PR DESCRIPTION
Resolving issue 179

- Line breaks are now adhered to
- When strings are too long or multi line, collapse them similarly to how we do with objects
- Arrays with objects are collapsed and can be viewed by pressing View array. Again following what is already done for View object

<img width="1217" height="501" alt="image" src="https://github.com/user-attachments/assets/19bf2990-7be5-4aad-bff8-4b71524abb85" />

<img width="1255" height="683" alt="image" src="https://github.com/user-attachments/assets/aaf80455-aa5d-4e9b-9321-a7392afd73cd" />

<img width="1263" height="826" alt="image" src="https://github.com/user-attachments/assets/ad9707c6-0928-409c-b715-bffaebf0db7b" />

Let me know if we like this UX. Or do we prefer another way of showing larger elements?