### PR TITLE
Potential fix for code scanning alert no. 14: Size computation for allocation may overflow

### DIFF
--- a/internal/core/glossary/sync.go
+++ b/internal/core/glossary/sync.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"reflect"
 	"slices"
 	"strings"
@@ -223,7 +224,12 @@ func descriptionOf(in TermInput) *string {
 // metadataOf carries the source's own metadata through, with synonyms
 // folded in because the table has no column for them.
 func metadataOf(in TermInput) map[string]interface{} {
-	metadata := make(map[string]interface{}, len(in.Metadata)+1)
+	capHint := len(in.Metadata)
+	if capHint < math.MaxInt {
+		capHint++
+	}
+
+	metadata := make(map[string]interface{}, capHint)
 	maps.Copy(metadata, in.Metadata)
 
 	if len(in.Synonyms) > 0 {


### PR DESCRIPTION
Potential fix for [https://github.com/marmotdata/marmot/security/code-scanning/14](https://github.com/marmotdata/marmot/security/code-scanning/14)

Use overflow-safe capacity computation before allocation in `metadataOf` in `internal/core/glossary/sync.go`.

Best fix: avoid direct `len(in.Metadata)+1`. Compute capacity with a guard:
- Start from `capHint := len(in.Metadata)`.
- Only increment if `capHint < math.MaxInt`; otherwise keep `capHint` unchanged.
- Allocate with `make(map[string]interface{}, capHint)`.

This preserves behavior (preallocates roughly same size; still allows inserting synonyms key) while removing overflow risk.  
Required changes:
1. Add `math` import in `internal/core/glossary/sync.go`.
2. Replace the allocation line/logic in `metadataOf` with guarded arithmetic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
