### PR TITLE
fix: plugin install on the chart's read-only rootfs

### DIFF
--- a/charts/marmot/Chart.yaml
+++ b/charts/marmot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: marmot
 description: Marmot is an open-source data catalog that helps teams discover, understand, and govern their data assets. It's designed for modern data ecosystems where data flows through multiple systems, formats and teams.
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: "0.10.0"
 icon: https://marmotdata.github.io/charts/marmot.png
 home: https://github.com/marmotdata/marmot

--- a/charts/marmot/templates/deployment.yaml
+++ b/charts/marmot/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
             {{- end }}
 
             # ---- Plugin cache (rootfs is read-only) ----
-            {{- if not (hasKey .Values.env "MARMOT_PLUGINS_DIR") }}
+            {{- if not (hasKey (.Values.env | default dict) "MARMOT_PLUGINS_DIR") }}
             - name: MARMOT_PLUGINS_DIR
               value: /var/lib/marmot/plugins
             {{- end }}

--- a/charts/marmot/templates/deployment.yaml
+++ b/charts/marmot/templates/deployment.yaml
@@ -142,6 +142,12 @@ spec:
             {{- end }}
             {{- end }}
 
+            # ---- Plugin cache (rootfs is read-only) ----
+            {{- if not (hasKey .Values.env "MARMOT_PLUGINS_DIR") }}
+            - name: MARMOT_PLUGINS_DIR
+              value: /var/lib/marmot/plugins
+            {{- end }}
+
             # ---- Additional environment variables ----
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
@@ -151,6 +157,11 @@ spec:
             - name: config
               mountPath: /etc/marmot
               readOnly: true
+            - name: plugins
+              mountPath: /var/lib/marmot/plugins
+            # plugin sockets and scratch space
+            - name: tmp
+              mountPath: /tmp
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -170,6 +181,10 @@ spec:
         - name: config
           configMap:
             name: {{ include "marmot.fullname" . }}-config
+        - name: plugins
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/marmot/tests/deployment_test.yaml
+++ b/charts/marmot/tests/deployment_test.yaml
@@ -227,6 +227,17 @@ tests:
             emptyDir: {}
         template: deployment.yaml
 
+  - it: should render with env set to null
+    set:
+      env: null
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MARMOT_PLUGINS_DIR
+            value: /var/lib/marmot/plugins
+        template: deployment.yaml
+
   - it: should let env override the plugin dir without a duplicate entry
     set:
       env:

--- a/charts/marmot/tests/deployment_test.yaml
+++ b/charts/marmot/tests/deployment_test.yaml
@@ -194,6 +194,68 @@ tests:
           value: false
         template: deployment.yaml
 
+  - it: should give the plugin cache and /tmp writable emptyDirs
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MARMOT_PLUGINS_DIR
+            value: /var/lib/marmot/plugins
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: plugins
+            mountPath: /var/lib/marmot/plugins
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: plugins
+            emptyDir: {}
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}
+        template: deployment.yaml
+
+  - it: should let env override the plugin dir without a duplicate entry
+    set:
+      env:
+        MARMOT_PLUGINS_DIR: /data/plugins
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MARMOT_PLUGINS_DIR
+            value: /var/lib/marmot/plugins
+        template: deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MARMOT_PLUGINS_DIR
+            value: /data/plugins
+        template: deployment.yaml
+
+  - it: should request ephemeral storage for the plugin cache by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests["ephemeral-storage"]
+          value: 2Gi
+        template: deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["ephemeral-storage"]
+          value: 2Gi
+        template: deployment.yaml
+
   - it: should set custom image tag
     set:
       image.tag: "custom-tag"

--- a/charts/marmot/values.yaml
+++ b/charts/marmot/values.yaml
@@ -57,9 +57,12 @@ resources:
   limits:
     cpu: 2000m
     memory: 2Gi
+    # the plugin cache downloaded at startup is over 1Gi
+    ephemeral-storage: 2Gi
   requests:
     cpu: 500m
     memory: 512Mi
+    ephemeral-storage: 2Gi
 
 livenessProbe:
   httpGet:


### PR DESCRIPTION
The default `securityContext` sets `readOnlyRootFilesystem` and the image has no writable `HOME`, so core plugin autoinstall fails at startup with `mkdir /.marmot: read-only file system` and the server runs without plugins.