### PR TITLE
bug: enforce the forced password gate on the API, not just the login page

### DIFF
--- a/internal/api/auth/authorise.go
+++ b/internal/api/auth/authorise.go
@@ -126,6 +126,13 @@ func (h *Handler) handleAuthorizeComplete(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// This endpoint authenticates on its own rather than through WithAuth, so
+	// the gate there does not cover it.
+	if usr.MustChangePassword {
+		common.RespondError(w, http.StatusForbidden, "Password change required")
+		return
+	}
+
 	if !h.HasPendingAuthorize(r) {
 		common.RespondError(w, http.StatusBadRequest, "No pending authorization")
 		return

--- a/internal/api/auth/authorise_test.go
+++ b/internal/api/auth/authorise_test.go
@@ -8,9 +8,14 @@ import (
 	"net/url"
 	"testing"
 
+	"context"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	coreauth "github.com/marmotdata/marmot/internal/core/auth"
+	"github.com/marmotdata/marmot/internal/core/user"
 	marmotOAuth2 "github.com/marmotdata/marmot/internal/oauth2"
-	"github.com/ory/fosite"
 	"github.com/marmotdata/marmot/pkg/config"
+	"github.com/ory/fosite"
 )
 
 func newAuthorizeHandler() *Handler {
@@ -215,5 +220,55 @@ func TestCompleteAuthorize_Flow(t *testing.T) {
 	checkReq.AddCookie(sessionCookie)
 	if h.HasPendingAuthorize(checkReq) {
 		t.Fatal("expected no pending authorize after completion")
+	}
+}
+
+// handleAuthorizeComplete authenticates outside WithAuth, so the password
+// change gate does not cover it; it has to refuse a pending change itself.
+func TestHandleAuthorizeComplete_PasswordChangePending(t *testing.T) {
+	h := newAuthorizeHandler()
+	h.authService = &mockAuthService{
+		validateTokenFn: func(_ context.Context, _ string) (*coreauth.Claims, error) {
+			return &coreauth.Claims{RegisteredClaims: jwt.RegisteredClaims{Subject: "u-1"}}, nil
+		},
+	}
+	h.userService = &mockUserService{
+		getFn: func(_ context.Context, _ string) (*user.User, error) {
+			return &user.User{ID: "u-1", Username: "admin", Active: true, MustChangePassword: true}, nil
+		},
+	}
+
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	hash := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(hash[:])
+	params := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {"test-client-1"},
+		"redirect_uri":          {"http://localhost:9999/callback"},
+		"state":                 {"test-state-123"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"scope":                 {"openid"},
+	}
+	authRec := httptest.NewRecorder()
+	h.handleAuthorize(authRec, httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+params.Encode(), nil))
+	var sessionCookie *http.Cookie
+	for _, c := range authRec.Result().Cookies() {
+		if c.Name == "oauth_session" {
+			sessionCookie = c
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("no oauth_session cookie")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/authorize/complete", nil)
+	req.Header.Set("Authorization", "Bearer initial-password-token")
+	req.AddCookie(sessionCookie)
+	rec := httptest.NewRecorder()
+	h.handleAuthorizeComplete(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for pending password change, got %d", rec.Code)
 	}
 }

--- a/internal/api/auth/token_exchange_test.go
+++ b/internal/api/auth/token_exchange_test.go
@@ -20,6 +20,7 @@ import (
 
 type mockAuthService struct {
 	generateTokenFn func(ctx context.Context, u *user.User, prefs map[string]interface{}) (string, error)
+	validateTokenFn func(ctx context.Context, token string) (*coreauth.Claims, error)
 }
 
 func (m *mockAuthService) GenerateToken(ctx context.Context, u *user.User, prefs map[string]interface{}) (string, error) {
@@ -34,6 +35,9 @@ func (m *mockAuthService) GenerateTokenForPrincipal(ctx context.Context, p corea
 }
 
 func (m *mockAuthService) ValidateToken(ctx context.Context, token string) (*coreauth.Claims, error) {
+	if m.validateTokenFn != nil {
+		return m.validateTokenFn(ctx, token)
+	}
 	return nil, nil
 }
 

--- a/internal/api/v1/common/middleware.go
+++ b/internal/api/v1/common/middleware.go
@@ -54,9 +54,9 @@ func GetOAuthAuthorizeCompleter() OAuthAuthorizeCompleter {
 	return globalOAuthAuthorizeCompleter
 }
 
-// UpdatePasswordPath is the route passwordChangeGate exempts; the registration
-// uses it too, since drift between them would lock a user with a pending
-// change out of the only endpoint that can clear it.
+// UpdatePasswordPath is the route passwordChangeGate exempts. RegisterRoutes
+// registers the handler under it, so that drift between the two cannot lock a
+// user with a pending change out of the only endpoint that can clear it.
 const UpdatePasswordPath = "/api/v1/users/update-password"
 
 // passwordChangeGate blocks every request from a user whose
@@ -67,7 +67,9 @@ const UpdatePasswordPath = "/api/v1/users/update-password"
 func passwordChangeGate(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		u, ok := r.Context().Value(UserContextKey).(*user.User)
-		if ok && u.MustChangePassword && r.URL.Path != UpdatePasswordPath {
+		// Every route is registered under a trailing-slash variant too, so the
+		// exemption has to match the same two spellings the mux does.
+		if ok && u.MustChangePassword && strings.TrimSuffix(r.URL.Path, "/") != UpdatePasswordPath {
 			RespondError(w, http.StatusForbidden, "Password change required")
 			return
 		}

--- a/internal/api/v1/common/middleware.go
+++ b/internal/api/v1/common/middleware.go
@@ -54,11 +54,28 @@ func GetOAuthAuthorizeCompleter() OAuthAuthorizeCompleter {
 	return globalOAuthAuthorizeCompleter
 }
 
+// passwordChangeGate blocks every request from a user whose
+// must_change_password is still set, except the password change itself.
+// Without it the forced change would only exist in the login UI: a token
+// obtained with an initial password would work on the whole API without the
+// password ever being changed.
+func passwordChangeGate(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		u, ok := r.Context().Value(UserContextKey).(*user.User)
+		if ok && u.MustChangePassword && r.URL.Path != "/api/v1/users/update-password" {
+			RespondError(w, http.StatusForbidden, "Password change required")
+			return
+		}
+		next(w, r)
+	}
+}
+
 // WithAuth middleware handles API key, JWT, and K8s ServiceAccount token authentication.
 func WithAuth(userService user.Service, authService auth.Service, cfg *config.Config) func(http.HandlerFunc) http.HandlerFunc {
 	resolver := auth.NewResolver(userService)
 	k8sValidator := globalK8sValidator
 	return func(next http.HandlerFunc) http.HandlerFunc {
+		next = passwordChangeGate(next)
 		return func(w http.ResponseWriter, r *http.Request) {
 			apiKey := r.Header.Get("X-API-Key")
 

--- a/internal/api/v1/common/middleware.go
+++ b/internal/api/v1/common/middleware.go
@@ -54,11 +54,33 @@ func GetOAuthAuthorizeCompleter() OAuthAuthorizeCompleter {
 	return globalOAuthAuthorizeCompleter
 }
 
+// UpdatePasswordPath is the route passwordChangeGate exempts; the registration
+// uses it too, since drift between them would lock a user with a pending
+// change out of the only endpoint that can clear it.
+const UpdatePasswordPath = "/api/v1/users/update-password"
+
+// passwordChangeGate blocks every request from a user whose
+// must_change_password is still set, except the password change itself.
+// Without it the forced change would only exist in the login UI: a token
+// obtained with an initial password would work on the whole API without the
+// password ever being changed.
+func passwordChangeGate(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		u, ok := r.Context().Value(UserContextKey).(*user.User)
+		if ok && u.MustChangePassword && r.URL.Path != UpdatePasswordPath {
+			RespondError(w, http.StatusForbidden, "Password change required")
+			return
+		}
+		next(w, r)
+	}
+}
+
 // WithAuth middleware handles API key, JWT, and K8s ServiceAccount token authentication.
 func WithAuth(userService user.Service, authService auth.Service, cfg *config.Config) func(http.HandlerFunc) http.HandlerFunc {
 	resolver := auth.NewResolver(userService)
 	k8sValidator := globalK8sValidator
 	return func(next http.HandlerFunc) http.HandlerFunc {
+		next = passwordChangeGate(next)
 		return func(w http.ResponseWriter, r *http.Request) {
 			apiKey := r.Header.Get("X-API-Key")
 

--- a/internal/api/v1/common/middleware_test.go
+++ b/internal/api/v1/common/middleware_test.go
@@ -19,6 +19,7 @@ func TestPasswordChangeGate(t *testing.T) {
 	}{
 		{name: "pending change is refused everywhere else", user: &user.User{MustChangePassword: true}, path: "/api/v1/assets", want: http.StatusForbidden},
 		{name: "pending change may change the password", user: &user.User{MustChangePassword: true}, path: "/api/v1/users/update-password", want: http.StatusOK},
+		{name: "the trailing-slash variant is exempt too", user: &user.User{MustChangePassword: true}, path: "/api/v1/users/update-password/", want: http.StatusOK},
 		{name: "settled user passes", user: &user.User{}, path: "/api/v1/assets", want: http.StatusOK},
 		{name: "non-user principals pass", user: nil, path: "/api/v1/assets", want: http.StatusOK},
 	}
@@ -54,8 +55,9 @@ func TestWithAuthPasswordChangePending(t *testing.T) {
 	})
 
 	for path, want := range map[string]int{
-		"/api/v1/assets":                http.StatusForbidden,
-		"/api/v1/users/update-password": http.StatusOK,
+		"/api/v1/assets":         http.StatusForbidden,
+		UpdatePasswordPath:       http.StatusOK,
+		UpdatePasswordPath + "/": http.StatusOK,
 	} {
 		req := httptest.NewRequest(http.MethodPost, path, nil)
 		req.Header.Set("X-API-Key", "key")

--- a/internal/api/v1/common/middleware_test.go
+++ b/internal/api/v1/common/middleware_test.go
@@ -1,0 +1,68 @@
+package common
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/marmotdata/marmot/internal/core/user"
+	"github.com/marmotdata/marmot/pkg/config"
+)
+
+func TestPasswordChangeGate(t *testing.T) {
+	tests := []struct {
+		name string
+		user *user.User
+		path string
+		want int
+	}{
+		{name: "pending change is refused everywhere else", user: &user.User{MustChangePassword: true}, path: "/api/v1/assets", want: http.StatusForbidden},
+		{name: "pending change may change the password", user: &user.User{MustChangePassword: true}, path: "/api/v1/users/update-password", want: http.StatusOK},
+		{name: "settled user passes", user: &user.User{}, path: "/api/v1/assets", want: http.StatusOK},
+		{name: "non-user principals pass", user: nil, path: "/api/v1/assets", want: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := passwordChangeGate(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			r := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			if tt.user != nil {
+				r = r.WithContext(context.WithValue(r.Context(), UserContextKey, tt.user))
+			}
+			w := httptest.NewRecorder()
+			h(w, r)
+			if w.Code != tt.want {
+				t.Fatalf("%s %s = %d, want %d", http.MethodPost, tt.path, w.Code, tt.want)
+			}
+		})
+	}
+}
+
+// The gate has to sit inside WithAuth rather than on individual routes: every
+// credential of the user must hit it, however the request authenticated.
+func TestWithAuthPasswordChangePending(t *testing.T) {
+	userSvc := &mockUserService{
+		validateAPIKeyFn: func(_ context.Context, _ string) (*user.User, error) {
+			return &user.User{ID: "u1", Active: true, MustChangePassword: true}, nil
+		},
+	}
+	handler := WithAuth(userSvc, &mockAuthService{}, &config.Config{})(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for path, want := range map[string]int{
+		"/api/v1/assets":                http.StatusForbidden,
+		"/api/v1/users/update-password": http.StatusOK,
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		req.Header.Set("X-API-Key", "key")
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+		if rec.Code != want {
+			t.Fatalf("POST %s = %d, want %d", path, rec.Code, want)
+		}
+	}
+}

--- a/internal/api/v1/users/handler.go
+++ b/internal/api/v1/users/handler.go
@@ -148,7 +148,7 @@ func (h *Handler) Routes() []common.Route {
 			},
 		},
 		{
-			Path:    "/api/v1/users/update-password",
+			Path:    common.UpdatePasswordPath,
 			Method:  http.MethodPost,
 			Handler: h.updatePassword,
 			Middleware: []func(http.HandlerFunc) http.HandlerFunc{

--- a/internal/core/user/service.go
+++ b/internal/core/user/service.go
@@ -23,7 +23,6 @@ var (
 	ErrPasswordRequired       = errors.New("password is required for non-OAuth users")
 	ErrCannotDeleteSelf       = errors.New("user can't delete self")
 	ErrCannotDeleteAdmin      = errors.New("can't delete admin user")
-	ErrPasswordChangeRequired = errors.New("password change required")
 )
 
 type User struct {


### PR DESCRIPTION
A token or API key of a user whose `must_change_password` is still set now answers 403 to everything except the password change itself. Before, the forced change only existed in the login UI: the login endpoint issued a fully privileged token regardless.