### PR TITLE
FIx/keep CLI contexts out of the Viper config

### DIFF
--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -9,7 +12,14 @@ import (
 
 // ContextEntry represents a saved server context.
 type ContextEntry struct {
-	Host string `yaml:"host" mapstructure:"host"`
+	Host string `json:"host"`
+}
+
+// ContextStore holds all saved contexts, keyed by context name. Contexts live
+// beside the config rather than in it: names are hostnames, and Viper is
+// dot-delimited, so writing them through Viper splits a name into nested keys.
+type ContextStore struct {
+	Contexts map[string]ContextEntry `json:"contexts"`
 }
 
 var contextCmd = &cobra.Command{
@@ -21,7 +31,10 @@ var contextListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all contexts",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		contexts := getContexts()
+		contexts, err := loadContexts()
+		if err != nil {
+			return err
+		}
 		current := currentContextName()
 
 		if len(contexts) == 0 {
@@ -59,7 +72,10 @@ var contextUseCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		contexts := getContexts()
+		contexts, err := loadContexts()
+		if err != nil {
+			return err
+		}
 
 		if _, ok := contexts[name]; !ok {
 			return fmt.Errorf("context %q not found", name)
@@ -81,14 +97,19 @@ var contextDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		contexts := getContexts()
+		contexts, err := loadContexts()
+		if err != nil {
+			return err
+		}
 
 		if _, ok := contexts[name]; !ok {
 			return fmt.Errorf("context %q not found", name)
 		}
 
 		delete(contexts, name)
-		viper.Set("contexts", contexts)
+		if err := saveContexts(contexts); err != nil {
+			return err
+		}
 
 		if currentContextName() == name {
 			viper.Set("current_context", "")
@@ -117,7 +138,10 @@ func getActiveContext() (string, *ContextEntry) {
 		return "", nil
 	}
 
-	contexts := getContexts()
+	contexts, err := loadContexts()
+	if err != nil {
+		return "", nil
+	}
 	ctx, ok := contexts[name]
 	if !ok {
 		return "", nil
@@ -126,33 +150,70 @@ func getActiveContext() (string, *ContextEntry) {
 	return name, &ctx
 }
 
-// getContexts returns all configured contexts.
-func getContexts() map[string]ContextEntry {
-	raw := viper.GetStringMap("contexts")
-	result := make(map[string]ContextEntry)
-
-	for name, v := range raw {
-		if entry, ok := v.(map[string]interface{}); ok {
-			host, _ := entry["host"].(string)
-			result[name] = ContextEntry{Host: host}
-		}
+func contextsPath() (string, error) {
+	dir, err := configDir()
+	if err != nil {
+		return "", err
 	}
-
-	return result
+	return filepath.Join(dir, "contexts.json"), nil
 }
 
-// setContext adds or updates a context in config and writes it.
+// loadContexts returns all saved contexts.
+func loadContexts() (map[string]ContextEntry, error) {
+	p, err := contextsPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]ContextEntry), nil
+		}
+		return nil, err
+	}
+
+	var store ContextStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", p, err)
+	}
+	if store.Contexts == nil {
+		store.Contexts = make(map[string]ContextEntry)
+	}
+	return store.Contexts, nil
+}
+
+func saveContexts(contexts map[string]ContextEntry) error {
+	p, err := contextsPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(ContextStore{Contexts: contexts}, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(p, data, 0o600)
+}
+
+// setContext adds or updates a context and makes it current.
 func setContext(name string, ctx ContextEntry) error {
-	contexts := getContexts()
+	contexts, err := loadContexts()
+	if err != nil {
+		return err
+	}
 	contexts[name] = ctx
 
-	raw := make(map[string]interface{})
-	for k, v := range contexts {
-		raw[k] = map[string]interface{}{"host": v.Host}
+	if err := saveContexts(contexts); err != nil {
+		return err
 	}
-	viper.Set("contexts", raw)
-	viper.Set("current_context", name)
 
+	viper.Set("current_context", name)
 	return writeConfig()
 }
 

--- a/internal/cmd/context_test.go
+++ b/internal/cmd/context_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -23,9 +25,60 @@ func TestSetAndGetContext(t *testing.T) {
 	err := setContext("example.com", ContextEntry{Host: "https://example.com"})
 	require.NoError(t, err)
 
-	contexts := getContexts()
+	contexts, err := loadContexts()
+	require.NoError(t, err)
 	assert.Contains(t, contexts, "example.com")
 	assert.Equal(t, "https://example.com", contexts["example.com"].Host)
+}
+
+// A context name is a hostname. Viper is dot-delimited, so a name kept in the
+// config would come back split; and any command that rewrites the config must
+// leave the contexts alone.
+func TestContextsSurviveAConfigWrite(t *testing.T) {
+	_, cleanup := setupTestConfigDir(t)
+	defer cleanup()
+	setupTestViper(t)
+
+	require.NoError(t, setContext("example.com", ContextEntry{Host: "https://example.com"}))
+	require.NoError(t, setContext("other.com", ContextEntry{Host: "https://other.com"}))
+
+	// A later process reads the config, then writes it for an unrelated key.
+	dir, err := configDir()
+	require.NoError(t, err)
+	viper.Reset()
+	viper.SetConfigFile(filepath.Join(dir, "config.yaml"))
+	require.NoError(t, viper.ReadInConfig())
+	viper.Set("output", "json")
+	require.NoError(t, writeConfig())
+
+	contexts, err := loadContexts()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]ContextEntry{
+		"example.com": {Host: "https://example.com"},
+		"other.com":   {Host: "https://other.com"},
+	}, contexts)
+}
+
+func TestLoadContextsReportsABrokenFile(t *testing.T) {
+	_, cleanup := setupTestConfigDir(t)
+	defer cleanup()
+
+	p, err := contextsPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o700))
+	require.NoError(t, os.WriteFile(p, []byte("{not json"), 0o600))
+
+	_, err = loadContexts()
+	assert.Error(t, err, "a broken file is not silently an empty one")
+}
+
+func TestLoadContextsWithoutAFile(t *testing.T) {
+	_, cleanup := setupTestConfigDir(t)
+	defer cleanup()
+
+	contexts, err := loadContexts()
+	require.NoError(t, err)
+	assert.Empty(t, contexts)
 }
 
 func TestCurrentContextName(t *testing.T) {

--- a/internal/cmd/credential_helper.go
+++ b/internal/cmd/credential_helper.go
@@ -92,7 +92,11 @@ func contextForRegistry(server string) (string, bool) {
 	if want == "" {
 		return "", false
 	}
-	for name, ctx := range getContexts() {
+	contexts, err := loadContexts()
+	if err != nil {
+		return "", false
+	}
+	for name, ctx := range contexts {
 		if registryHost(ctx.Host) == want {
 			return name, true
 		}
@@ -103,7 +107,11 @@ func contextForRegistry(server string) (string, bool) {
 // helperList maps every registry with a live token to its user name.
 func helperList() map[string]string {
 	out := map[string]string{}
-	for name, ctx := range getContexts() {
+	contexts, err := loadContexts()
+	if err != nil {
+		return out
+	}
+	for name, ctx := range contexts {
 		if _, ok := getCachedToken(name); ok {
 			out[registryHost(ctx.Host)] = registryUsername
 		}

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -296,7 +296,11 @@ func resolveLoginHost(args []string) (host, contextName string, err error) {
 	if len(args) > 0 {
 		// A bare name that matches a saved context keeps that context's
 		// URL, so "marmot login localhost:8080" does not turn http into https.
-		if ctx, ok := getContexts()[args[0]]; ok && !strings.Contains(args[0], "://") {
+		contexts, err := loadContexts()
+		if err != nil {
+			return "", "", err
+		}
+		if ctx, ok := contexts[args[0]]; ok && !strings.Contains(args[0], "://") {
 			host, contextName = ctx.Host, args[0]
 		} else {
 			host = normalizeHost(args[0])


### PR DESCRIPTION
Context names are hostnames and Viper is dot-delimited, so a context stored as a Viper key does not survive a write: WriteConfig serialises AllSettings, which flattens the config layer to dot-separated keys and splits them again on read. "example .com" comes back as a nested "example: com:", and the context is lost.

Contexts move to contexts.json beside credentials.json, which already holds a map keyed by the same hostnames, read and written directly. Viper keeps only current_context, whose value may contain dots without being parsed as a path. loadContexts reports a malformed file instead of reading it as empty, so a broken store no longer looks like "not logged in".